### PR TITLE
StateをCLOSINGにするタイミングでpingSenderを破棄する

### DIFF
--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -701,6 +701,8 @@ namespace WebSocketSharp
           return;
         }
 
+        if (_pingSender != null)
+          _pingSender.Dispose ();
         _readyState = WebSocketState.CLOSING;
       }
 
@@ -718,8 +720,6 @@ namespace WebSocketSharp
 
       _readyState = WebSocketState.CLOSED;
       try {
-        if (_pingSender != null)
-          _pingSender.Dispose ();
         OnClose.Emit (this, args);
       }
       catch (Exception ex) {

--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -1023,6 +1023,17 @@ namespace WebSocketSharp
       return res;
     }
 
+    private bool pingsend (byte [] frame)
+    {
+      lock (_forConn) {
+        if (_readyState != WebSocketState.OPEN) {
+          return false;
+        }
+
+        return _stream.Write (frame);
+      }
+    }
+
     private bool send (byte [] frame)
     {
       lock (_forConn) {
@@ -1341,7 +1352,7 @@ namespace WebSocketSharp
     internal bool Ping ()
     {
       _pingSentAt = DateTime.Now.Ticks / 10000; // Millseconds
-      return send (WsFrame.CreatePingFrame (Mask.MASK).ToByteArray ());
+      return pingsend (WsFrame.CreatePingFrame (Mask.MASK).ToByteArray ());
     }
 
     // As server, used to broadcast


### PR DESCRIPTION
CLOSINGになった時点で送信できなくなるため、pingSenderも止めなければならなかった。
運悪くCLOSINGからCLOSEDになる間にPingを送ろうとした場合、`send()`でエラーになってしまっていた。